### PR TITLE
CCE-47 configurable username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,6 @@ ee.db-port=123
 ee.db-password=password
 ee.db-user=username
 ee.database=Awesome_Database
+ee.header.password=MockEEPassword
+ee.header.username=MockEEUsername
 ```

--- a/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
+++ b/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
@@ -2,6 +2,7 @@ package gov.va.api.med.mockee;
 
 import java.util.List;
 import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +21,11 @@ import org.springframework.xml.xsd.XsdSchema;
 @EnableWs
 @Configuration
 public class WebServiceConfig extends WsConfigurerAdapter {
+  @Value("${ee.header.username}")
+  private String eeHeaderUsername;
+
+  @Value("${ee.header.password}")
+  private String eeHeaderPassword;
 
   @Override
   public void addInterceptors(List<EndpointInterceptor> interceptors) {
@@ -59,7 +65,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
     SimplePasswordValidationCallbackHandler callbackHandler =
         new SimplePasswordValidationCallbackHandler();
     Properties users = new Properties();
-    users.setProperty("MockEEUsername", "MockEEPassword");
+    users.setProperty(eeHeaderUsername, eeHeaderPassword);
     callbackHandler.setUsers(users);
     return callbackHandler;
   }

--- a/mock-ee/src/main/resources/application.properties
+++ b/mock-ee/src/main/resources/application.properties
@@ -11,3 +11,5 @@ ee.db-host=unset
 ee.db-port=unset
 ee.db-password=unset
 ee.db-user=unset
+ee.header.password=unset
+ee.header.username=unset

--- a/src/scripts/make-configs.sh
+++ b/src/scripts/make-configs.sh
@@ -105,5 +105,7 @@ configValue mock-ee $PROFILE ee.db-host "$DB_HOST"
 configValue mock-ee $PROFILE ee.db-port "$DB_PORT"
 configValue mock-ee $PROFILE ee.db-password "$DB_PASSWORD"
 configValue mock-ee $PROFILE ee.db-user "$DB_USER"
+configValue mock-ee $PROFILE ee.header.password "MockEEPassword"
+configValue mock-ee $PROFILE ee.header.username "MockEEUsername"
 
 checkForUnsetValues mock-ee $PROFILE


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/CCE-47

Add back `ee.header.username` and `ee.header.password` properties. They default to `MockEEUsername` and `MockEEPassword` for local development, but should be overriddeen in higher environments.