### PR TITLE
Update smoke & regression to https

### DIFF
--- a/mock-ee/src/main/docker/entrypoint.sh
+++ b/mock-ee/src/main/docker/entrypoint.sh
@@ -50,7 +50,7 @@ trackStatus () {
 # Send requests to all of mock-ee's available endpoints
 httpListenerTests () {
 
-  ENDPOINT_DOMAIN_NAME="http://$ENDPOINT_DOMAIN_NAME"
+  ENDPOINT_DOMAIN_NAME="https://$ENDPOINT_DOMAIN_NAME"
 
   for path in "${PATHS[@]}"
     do


### PR DESCRIPTION
JIRA Issue: https://vasdvp.atlassian.net/browse/CCE-60

Since this is going through the LB, it needs to be HTTPS, even though the Mock-EE communication is HTTP to match the E&E endpoint.

