### PR TITLE
Prepended /v0 to ws call, health check remains same

### DIFF
--- a/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
+++ b/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
@@ -21,6 +21,9 @@ import org.springframework.xml.xsd.XsdSchema;
 @EnableWs
 @Configuration
 public class WebServiceConfig extends WsConfigurerAdapter {
+
+  public static final String mockEeVersion = "/v0";
+
   @Value("${ee.header.username}")
   private String eeHeaderUsername;
 
@@ -37,7 +40,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
   public DefaultWsdl11Definition defaultWsdl11Definition(XsdSchema eeSchema) {
     DefaultWsdl11Definition wsdl11Definition = new DefaultWsdl11Definition();
     wsdl11Definition.setPortTypeName("SummaryPort");
-    wsdl11Definition.setLocationUri("/v0/ws");
+    wsdl11Definition.setLocationUri(mockEeVersion + "/ws");
     wsdl11Definition.setTargetNamespace("http://jaxws.webservices.esr.med.va.gov/schemas");
     wsdl11Definition.setSchema(eeSchema);
     return wsdl11Definition;
@@ -56,7 +59,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
     MessageDispatcherServlet servlet = new MessageDispatcherServlet();
     servlet.setApplicationContext(applicationContext);
     servlet.setTransformWsdlLocations(true);
-    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, "/v0/ws/*");
+    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, mockEeVersion + "/ws/*");
   }
 
   /** Validation for user/password. */

--- a/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
+++ b/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
@@ -37,7 +37,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
   public DefaultWsdl11Definition defaultWsdl11Definition(XsdSchema eeSchema) {
     DefaultWsdl11Definition wsdl11Definition = new DefaultWsdl11Definition();
     wsdl11Definition.setPortTypeName("SummaryPort");
-    wsdl11Definition.setLocationUri("/ws");
+    wsdl11Definition.setLocationUri("/v0/ws");
     wsdl11Definition.setTargetNamespace("http://jaxws.webservices.esr.med.va.gov/schemas");
     wsdl11Definition.setSchema(eeSchema);
     return wsdl11Definition;
@@ -56,7 +56,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
     MessageDispatcherServlet servlet = new MessageDispatcherServlet();
     servlet.setApplicationContext(applicationContext);
     servlet.setTransformWsdlLocations(true);
-    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, "/ws/*");
+    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, "/v0/ws/*");
   }
 
   /** Validation for user/password. */


### PR DESCRIPTION
JIRA Issue: https://vasdvp.atlassian.net/browse/CCE-62

Prepended /v0 to ws call, health check remains same so LB & Ingress do not need to know version information.