### PR TITLE
Task/cce 62 add version to ws path

### DIFF
--- a/mock-ee/src/main/docker/entrypoint.sh
+++ b/mock-ee/src/main/docker/entrypoint.sh
@@ -59,7 +59,7 @@ httpListenerTests () {
       trackStatus
     done
 
-  path="/ws"
+  path="/v0/ws"
   request_url="$ENDPOINT_DOMAIN_NAME$BASE_PATH$path"
   status_code=$(curl -X POST -k --write-out %{http_code} --silent --output /dev/null "$request_url" -H 'Content-Type: text/xml' -d '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sch="http://jaxws.webservices.esr.med.va.gov/schemas" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
     <SOAP-ENV:Header>

--- a/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
+++ b/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
@@ -21,6 +21,9 @@ import org.springframework.xml.xsd.XsdSchema;
 @EnableWs
 @Configuration
 public class WebServiceConfig extends WsConfigurerAdapter {
+
+  public static final String mockEeVersion = "/v0";
+
   @Value("${ee.header.username}")
   private String eeHeaderUsername;
 
@@ -37,7 +40,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
   public DefaultWsdl11Definition defaultWsdl11Definition(XsdSchema eeSchema) {
     DefaultWsdl11Definition wsdl11Definition = new DefaultWsdl11Definition();
     wsdl11Definition.setPortTypeName("SummaryPort");
-    wsdl11Definition.setLocationUri("/v0/ws");
+    wsdl11Definition.setLocationUri(mockEeVersion + "/ws");
     wsdl11Definition.setTargetNamespace("http://jaxws.webservices.esr.med.va.gov/schemas");
     wsdl11Definition.setSchema(eeSchema);
     return wsdl11Definition;
@@ -56,7 +59,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
     MessageDispatcherServlet servlet = new MessageDispatcherServlet();
     servlet.setApplicationContext(applicationContext);
     servlet.setTransformWsdlLocations(true);
-    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, "/v0/ws/*");
+    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, mockEeVersion + "/ws/*");
   }
 
   /** Validation for user/password. */

--- a/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
+++ b/mock-ee/src/main/java/gov/va/api/med/mockee/WebServiceConfig.java
@@ -37,7 +37,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
   public DefaultWsdl11Definition defaultWsdl11Definition(XsdSchema eeSchema) {
     DefaultWsdl11Definition wsdl11Definition = new DefaultWsdl11Definition();
     wsdl11Definition.setPortTypeName("SummaryPort");
-    wsdl11Definition.setLocationUri("/ws");
+    wsdl11Definition.setLocationUri("/v0/ws");
     wsdl11Definition.setTargetNamespace("http://jaxws.webservices.esr.med.va.gov/schemas");
     wsdl11Definition.setSchema(eeSchema);
     return wsdl11Definition;
@@ -56,7 +56,7 @@ public class WebServiceConfig extends WsConfigurerAdapter {
     MessageDispatcherServlet servlet = new MessageDispatcherServlet();
     servlet.setApplicationContext(applicationContext);
     servlet.setTransformWsdlLocations(true);
-    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, "/ws/*");
+    return new ServletRegistrationBean<MessageDispatcherServlet>(servlet, "/v0/ws/*");
   }
 
   /** Validation for user/password. */


### PR DESCRIPTION
One additional update since the base path no longer includes the `/v0`.

The deployment repo will have the base_path update next along with the version update.