### PR TITLE
Removed the child pom groupId entry, renamed artifact to mock-ee

### DIFF
--- a/mock-ee/pom.xml
+++ b/mock-ee/pom.xml
@@ -6,8 +6,7 @@
     <artifactId>health-apis-parent</artifactId>
     <version>2.0.5</version>
   </parent>
-  <groupId>gov.va.api.health.mockee</groupId>
-  <artifactId>health-apis-mock-ee</artifactId>
+  <artifactId>mock-ee</artifactId>
   <version>1.0.20-SNAPSHOT</version>
   <name>health-apis-mock-ee</name>
   <properties>


### PR DESCRIPTION
JIRA Issue: https://vasdvp.atlassian.net/browse/CCE-75

Removed the unnecessary groupid declaration from the child pom since it was already inheriting from the parent pom.

