### PR TITLE
edit entrypoint.sh

### DIFF
--- a/mock-ee-tests/src/main/docker/entrypoint.sh
+++ b/mock-ee-tests/src/main/docker/entrypoint.sh
@@ -50,7 +50,9 @@ trackStatus () {
 # Send requests to all of mock-ee's available endpoints
 httpListenerTests () {
 
-  ENDPOINT_DOMAIN_NAME="https://$ENDPOINT_DOMAIN_NAME"
+  if [[ ! "$ENDPOINT_DOMAIN_NAME" == http* ]]; then
+      ENDPOINT_DOMAIN_NAME="https://$ENDPOINT_DOMAIN_NAME"
+  fi
 
   for path in "${PATHS[@]}"
     do


### PR DESCRIPTION
Edit to script will allow for HTTP if at `docker run` time you specify an HTTP URL. example: adding `K8S_LOAD_BALANCER=http://127.0.0.1:9090` to regular run command.
Related story: https://vasdvp.atlassian.net/browse/API-1577