### PR TITLE
Mock EE: Upgrade to 7.0.2 parent

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @department-of-veterans-affairs/lighthouse-shanktopus
+* @department-of-veterans-affairs/lighthouse-axolotl

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 standardMavenPipeline {
   healthApisMavenImage='vasdvp/health-apis-dev-tools:mvn-3.6-jdk-14'
-  slackChannels = [ 'health_apis_jenkins', 'shanktalerts' ]
+  slackChannels = [ 'health_apis_jenkins', 'axolerts' ]
 }

--- a/mock-ee-tests/pom.xml
+++ b/mock-ee-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.0.2</version>
     <relativePath/>
   </parent>
   <artifactId>mock-ee-tests</artifactId>

--- a/mock-ee/pom.xml
+++ b/mock-ee/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>7.0.1</version>
+    <version>7.0.2</version>
     <relativePath/>
   </parent>
   <artifactId>mock-ee</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.0.2</version>
   </parent>
   <artifactId>mock-ee-parent</artifactId>
   <version>3.0.3-SNAPSHOT</version>


### PR DESCRIPTION
https://vajira.max.gov/browse/API-1607
Updated version and changed code owner and alerts.